### PR TITLE
Updating all Swagger spec H1 title 

### DIFF
--- a/api_docs/Activity.yml
+++ b/api_docs/Activity.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Activity API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/activities/permissions: 

--- a/api_docs/AuthorizationServer.yml
+++ b/api_docs/AuthorizationServer.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Authorization Server API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/saml/identityproviders: 

--- a/api_docs/Extension.yml
+++ b/api_docs/Extension.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Extension API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/extensions/{extensionId}/disable: 

--- a/api_docs/Index.yml
+++ b/api_docs/Index.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Index API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/indexes/{indexId}/raw: 

--- a/api_docs/Notification.yml
+++ b/api_docs/Notification.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Notification API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/subscriptions/me/{subscriptionId}: 

--- a/api_docs/Platform.yml
+++ b/api_docs/Platform.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Platform API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/backups/page: 

--- a/api_docs/Privilege.yml
+++ b/api_docs/Privilege.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Privilege API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/privileges/apikeys: 

--- a/api_docs/PushApi.yml
+++ b/api_docs/PushApi.yml
@@ -1,7 +1,7 @@
 ---
   info: 
     version: "2016-03-03T13:22:11Z"
-    title: "Push API"
+    title: "Push API Reference - Coveo Cloud V2"
   paths: 
     /organizations/{organizationId}/sources/{sourceId}/status: 
       post: 

--- a/api_docs/SearchApi.yml
+++ b/api_docs/SearchApi.yml
@@ -1,7 +1,7 @@
 ---
   swagger: "2.0"
   info: 
-    title: "Coveo Search API"
+    title: "Search API Reference - Coveo Cloud"
     version: "1.0.0"
     description: "Documentation for Coveo Search API"
     termsOfService: "http://www.coveo.com/en/support/terms-agreements"

--- a/api_docs/SecurityCache.yml
+++ b/api_docs/SecurityCache.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Security Cache API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/organizations/{organizationId}/securitycache/refresh: 

--- a/api_docs/Source.yml
+++ b/api_docs/Source.yml
@@ -7,7 +7,7 @@
       email: "support@coveo.com"
     description: "API for Coveo Platform"
     license: {}
-    title: "Coveo Platform API"
+    title: "Source API Reference - Coveo Cloud V2"
     version: "1.0"
   paths: 
     /rest/sourceTokenRetriever/gmail/authorize: 

--- a/api_docs/SourceLogsApi.yml
+++ b/api_docs/SourceLogsApi.yml
@@ -1,7 +1,7 @@
 ---
   info: 
     version: "2016-03-03T13:22:11Z"
-    title: "Document Logs API"
+    title: "Source Logs API Reference - Coveo Cloud V2"
   paths: 
     /organizations/{organizationId}: 
       post: 

--- a/api_docs/UsageAnalytics.yml
+++ b/api_docs/UsageAnalytics.yml
@@ -1,7 +1,7 @@
 ---
   info: 
     version: "1.0"
-    title: "Usage Analytics"
+    title: "Usage Analytics API Reference - Coveo Cloud"
   paths: 
     /v14/exports/status: 
       get: 


### PR DESCRIPTION
Titles now have the form “api_name API Referenc……e - Coveo Cloud V2” (except Search and UA that are “Coveo Cloud” since both work with Cloud V1 and V2).